### PR TITLE
[Kaizen] Ai Reimage refund credits + editor mode from url

### DIFF
--- a/functions/api/create-prediction.js
+++ b/functions/api/create-prediction.js
@@ -57,14 +57,10 @@ export async function onRequestPost(context) {
   })
 
   // Deduct the required credits from the license
-  const { error: creditsError } = await supabase
-    .from('license_ai_credits')
-    .update({
-      balance: data.balance - requiredCredits,
-      api_calls_count: data.api_calls_count + 1,
-    })
-    .eq('license_key', license_key)
-    .eq('status', 'active')
+  const { error: creditsError } = await supabase.rpc('decrement_balance', {
+    decrement_by: requiredCredits,
+    p_license_key: license_key,
+  })
 
   if (creditsError) {
     return new Response(JSON.stringify({ error: creditsError.message }))

--- a/functions/api/get-prediction.js
+++ b/functions/api/get-prediction.js
@@ -1,9 +1,12 @@
 import Replicate from 'replicate'
+import { createClient } from '@supabase/supabase-js'
 
 export async function onRequestGet(context) {
   // Extract the prediction_id from the query parameters
   const url = new URL(context.request.url)
   const prediction_id = url.searchParams.get('prediction_id')
+  const license_key = url.searchParams.get('license_key')
+  const supabaseUrl = context.env.VITE_SUPABASE_URL
 
   if (!prediction_id) {
     return new Response(
@@ -21,6 +24,24 @@ export async function onRequestGet(context) {
   })
 
   const prediction = await replicate.predictions.get(prediction_id)
+
+  if (prediction.status === 'failed') {
+    const getServiceSupabase = () =>
+      createClient(supabaseUrl, context.env.SUPABASE_SERVICE_KEY)
+
+    // refund the credits to the license
+    const supabase = getServiceSupabase()
+    const requiredCredits = prediction.input.num_samples * 4
+
+    const { error } = await supabase.rpc('increment_balance', {
+      increment_by: requiredCredits,
+      p_license_key: license_key,
+    })
+
+    if (error) {
+      return new Response(JSON.stringify({ error: error.message }))
+    }
+  }
 
   // Return the prediction result as JSON
   return new Response(JSON.stringify(prediction), {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+import { useParams, useNavigate } from 'react-router-dom'
 import { useEffect, useState, useRef } from 'react'
 import './App.css'
 import { useForm } from 'react-hook-form'
@@ -15,10 +16,13 @@ import { useEditorMode } from './context/EditorModeContext'
 import ToolBarAI from './components/ToolBarAI'
 import EditorLinks from './components/EditorLinks'
 import AICanvasFeed from './components/AICanvasFeed'
+import { editorModes } from './components/editorModes'
 
 function App() {
   const user = useUser()
-  const { mode } = useEditorMode()
+  const { mode: urlMode } = useParams()
+  const navigate = useNavigate()
+  const { mode, setMode } = useEditorMode()
   const fingerprint = useFingerprint()
   const { checkLicense } = useCheckLicense()
   const { license } = useLicense()
@@ -180,6 +184,20 @@ function App() {
       checkLicense(user, fingerprint)
     }
   }, [user, fingerprint])
+
+  useEffect(() => {
+    console.log('urlMode', urlMode)
+    if (urlMode) {
+      // check if the mode is valid (exists as a mode in editorModes)
+      const modeExists = editorModes.some((item) => item.mode === urlMode)
+      if (modeExists) {
+        setMode(urlMode)
+      } else {
+        // change route to default mode
+        navigate('/app/screenshot')
+      }
+    }
+  }, [urlMode, setMode])
 
   return (
     <div

--- a/src/components/AICanvasFeed.jsx
+++ b/src/components/AICanvasFeed.jsx
@@ -63,6 +63,12 @@ export default function AICanvasFeed() {
             <p className="text-default-500">
               This can take several minutes, depending on the server load.
             </p>
+            <Progress
+              size="sm"
+              isIndeterminate
+              aria-label="Loading..."
+              className="max-w-md"
+            />
           </>
         )
       case 'processing':
@@ -73,6 +79,12 @@ export default function AICanvasFeed() {
             <p className="text-default-500">
               Please do not refresh or close the window during the process.
             </p>
+            <Progress
+              size="sm"
+              isIndeterminate
+              aria-label="Loading..."
+              className="max-w-md"
+            />
           </>
         )
       case 'succeeded':
@@ -86,8 +98,9 @@ export default function AICanvasFeed() {
       case 'failed':
         return (
           <>
+            <Image src="/empty-states/dark/10.svg" width={100} height={100} />
             <h4>Image processing failed.</h4>
-            <p className="text-error">
+            <p className="text-default-500">
               {image?.errorMessage ||
                 'Please try again or contact support if the issue persists.'}
             </p>
@@ -192,12 +205,6 @@ export default function AICanvasFeed() {
                 <CardBody className="w-full h-full">
                   <div className="flex flex-col items-center justify-center gap-3 py-4 w-full h-full">
                     {renderContentBasedOnStatus(image)}
-                    <Progress
-                      size="sm"
-                      isIndeterminate
-                      aria-label="Loading..."
-                      className="max-w-md"
-                    />
                     <Button
                       startContent={<PiTerminalBold fontSize="1rem" />}
                       size="sm"

--- a/src/components/EditorModeSelector.jsx
+++ b/src/components/EditorModeSelector.jsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom'
 import {
   Button,
   useDisclosure,
@@ -10,42 +11,15 @@ import {
   ModalFooter,
 } from '@nextui-org/react'
 import { useEditorMode } from '../context/EditorModeContext'
-import {
-  PiImageDuotone,
-  PiCodeBlockDuotone,
-  PiMagicWandDuotone,
-  PiFadersHorizontalBold,
-  PiCheckBold,
-} from 'react-icons/pi'
+import { PiFadersHorizontalBold, PiCheckBold } from 'react-icons/pi'
+import { editorModes } from './editorModes'
 
 function EditorModeSelector() {
-  const { mode, setMode } = useEditorMode()
-
-  const availableModes = [
-    {
-      title: 'Screenshot',
-      description: 'Beautify screenshots in seconds.',
-      icon: <PiImageDuotone fontSize="1.5rem" />,
-      mode: 'screenshot',
-    },
-    {
-      title: 'Dev',
-      description: 'Generate screenshots for your code snippets.',
-      icon: <PiCodeBlockDuotone fontSize="1.5rem" />,
-      mode: 'dev',
-    },
-    {
-      title: 'AI Reimagine',
-      description:
-        'Transform your images into new creations across multiple visual styles.',
-      icon: <PiMagicWandDuotone fontSize="1.5rem" />,
-      mode: 'ai',
-      isDisabled: false,
-    },
-  ]
+  const navigate = useNavigate()
+  const { mode } = useEditorMode()
 
   const handleModeChange = (mode) => {
-    setMode(mode)
+    navigate(`/app/${mode}`)
     onOpenChange()
   }
 
@@ -75,7 +49,7 @@ function EditorModeSelector() {
           </ModalHeader>
           <ModalBody className="p-4 w-full">
             <Listbox selectedKeys={[0]} className="w-full" variant="faded">
-              {availableModes.map((item, index) => (
+              {editorModes.map((item, index) => (
                 <ListboxItem
                   key={index}
                   // variant="bordered

--- a/src/components/ToolBarAI.jsx
+++ b/src/components/ToolBarAI.jsx
@@ -142,7 +142,7 @@ const ToolBarAI = () => {
 
       try {
         const response = await axios.get(
-          `/api/get-prediction?prediction_id=${predictionId}`,
+          `/api/get-prediction?prediction_id=${predictionId}&license_key=${license.deviceLicense.license_key}`,
           {
             signal: controller.signal, // Use the signal in the request
           }
@@ -173,6 +173,8 @@ const ToolBarAI = () => {
           console.error('Prediction failed:', response.data)
           displayToast('error', 'Failed to generate image, credits refunded')
           updateImage(predictionId, { status, logs })
+          // force a re-render to update the credits
+          setAiCredits((prev) => prev + creditsCost)
           break
         }
 

--- a/src/components/editorModes.jsx
+++ b/src/components/editorModes.jsx
@@ -1,0 +1,28 @@
+import {
+  PiImageDuotone,
+  PiCodeBlockDuotone,
+  PiMagicWandDuotone,
+} from 'react-icons/pi'
+
+export const editorModes = [
+  {
+    title: 'Screenshot',
+    description: 'Beautify screenshots in seconds.',
+    icon: <PiImageDuotone fontSize="1.5rem" />,
+    mode: 'screenshot',
+  },
+  {
+    title: 'Dev',
+    description: 'Generate screenshots for your code snippets.',
+    icon: <PiCodeBlockDuotone fontSize="1.5rem" />,
+    mode: 'dev',
+  },
+  {
+    title: 'AI Reimagine',
+    description:
+      'Transform your images into new creations across multiple visual styles.',
+    icon: <PiMagicWandDuotone fontSize="1.5rem" />,
+    mode: 'ai',
+    isDisabled: false,
+  },
+]

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -69,7 +69,7 @@ root.render(
                           }
                         />
                         <Route
-                          path="/app"
+                          path="/app/:mode"
                           element={
                             <section
                               id="app"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new editor modes with specific functionalities and navigation paths.
	- Introduced progress and error image components in AI Canvas Feed during different states.
	- Enhanced navigation in the app using URL modes and react-router-dom.
- **Bug Fixes**
	- Implemented credit refund mechanism for failed predictions.
- **Refactor**
	- Updated credit deduction method to use remote procedure calls.
	- Modified API requests to include `license_key` and handle state updates related to AI credits.
- **Style**
	- Enhanced user interface to display loading progress and error states more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->